### PR TITLE
Colorscheme を追加

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -103,6 +103,11 @@ Plug 'tpope/vim-rails'
 Plug 'slim-template/vim-slim', { 'for': 'slim' }
 Plug 'kchmck/vim-coffee-script', { 'for': 'coffee' }
 
+" Colorschemes
+Plug 'tomasr/molokai'
+Plug 'sjl/badwolf'
+Plug 'altercation/vim-colors-solarized'
+
 call plug#end()
 
 " }}}

--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ If you find some troubles with reading `vimrc` by every section is folded. Just 
 
 By default, Leader key is mapped to `Space`.
 
+### Colorschemes
+
+The following additional coloschemes are available:
+
+- [molokai](https://github.com/tomasr/molokai)
+- [badwolf](https://github.com/sjl/badwolf)
+- [solarized](https://github.com/altercation/vim-colors-solarized)
+
+Add the theme you prefer in `~/.vimrc.local`, like:
+
+```vim
+colorscheme molokai
+```
+
+See the website for each colorscheme for details.
+
 ### Unite
 
 The unite is a plugin which can search and display information from arbitrary sources like files, buffers or recently used files.


### PR DESCRIPTION
メジャーどころを追加しました。設定は `~/.vimrc.local` でやります。
- [molokai](https://github.com/tomasr/molokai)
- [badwolf](https://github.com/sjl/badwolf)
- [solarized](https://github.com/altercation/vim-colors-solarized)
