### PR TITLE
vim-blockle plugin

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -100,6 +100,7 @@ Plug 'tpope/vim-surround'
 Plug 'tpope/vim-endwise', { 'for': 'ruby' }
 Plug 'tpope/vim-cucumber', { 'for': 'cucumber' }
 Plug 'tpope/vim-rails'
+Plug 'jgdavey/vim-blockle', { 'for': 'ruby' }
 Plug 'slim-template/vim-slim', { 'for': 'slim' }
 Plug 'kchmck/vim-coffee-script', { 'for': 'coffee' }
 

--- a/README.md
+++ b/README.md
@@ -253,3 +253,11 @@ ctrlp is a full path fuzzy file etc finder for vim.
 - `Ctrl + p` : open ctrlp, then show magaged files via git
 
 For more information, visit https://github.com/ctrlpvim/ctrlp.vim or `:help ctrlp`.
+
+### vim-blockle
+
+vim-blockle is block syntax toggle plugin.
+
+- `<Leader>b` : Convert `{ ... }` into `do ... end` and vice versa.
+
+For more information, visit https://github.com/jgdavey/vim-blockle or `:help blockle`.


### PR DESCRIPTION
rubyのブロックのsyntaxをtoggleするプラグインを入れました。ブロックの中で `<Leader>b` をすると、下の二つを切り替えてくれます。

```
# one line
foo.each { |e| e.bar }  

# multiple lines
foo.each do |e|
  e.bar
end
```
