### PR TITLE
古い Ruby の Hash シンタックスを新しいものにする置換のキーマップを追加

### DIFF
--- a/.vim/ftplugin/ruby.vim
+++ b/.vim/ftplugin/ruby.vim
@@ -2,3 +2,7 @@ set expandtab
 set tabstop=2
 set shiftwidth=2
 set softtabstop=0
+
+" Convert to new Hash syntax
+nnoremap <Leader><Leader>rh :<C-u>%s/:\([^ ]*\)\(\s*\)=>/\1:/g<Return>
+xnoremap <Leader><Leader>rh :<C-u>'<,'>s/:\([^ ]*\)\(\s*\)=>/\1:/g<Return>


### PR DESCRIPTION
`<Leader><Leader>rh` で、

``` ruby
h = { :foo => 'Foo', :bar => 'Bar' }
```

を

``` ruby
h = { foo: 'Foo', bar: 'Bar' }
```

に変換します。単なる置換のキーマッピングです。

normal モードではバッファ全体、visual モードでは選択範囲が対象になります。

そんなに頻繁には使わないだろうから覚えにくいキーマップですが、それなりに使うことがありその度に正規表現をググるのは嫌なので使いたいときに参照できるようなメモ的な意味もあります。
