### PR TITLE
分割windowのときにwindowを保持したままバッファだけを消すキーマップ

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -69,6 +69,9 @@ nnoremap <Right> :echoe<Space>"Use l"<Return>
 nnoremap <Up> :echoe<Space>"Use k"<Return>
 nnoremap <Down> :echoe<Space>"Use j"<Return>
 
+" Deleting a buffer without closing the window
+nnoremap <silent> <leader>bd :bprevious\|:bdelete<Space>#<Return>
+
 " }}}
 
 " Plugins


### PR DESCRIPTION
bufferは消したいけど、windowの分割状態は保持したいときに役に立つコマンドのショートカットとしてキーマップを追加しました。

`:bd` ではbufferだけなく表示しているwindowまで閉じますが、 `<Leader>bd` を使うことでwindowの状態を保持できます。

関連: #5 
