### PR TITLE
vim-better-whitespace を追加

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -102,6 +102,7 @@ Plug 'tyru/open-browser.vim', { 'for': 'markdown' }
 Plug 'tyru/caw.vim'
 Plug 'osyo-manga/vim-anzu'
 Plug 'osyo-manga/vim-over'
+Plug 'ntpeters/vim-better-whitespace'
 Plug 'tpope/vim-fugitive'
 Plug 'tpope/vim-surround'
 Plug 'tpope/vim-endwise', { 'for': 'ruby' }

--- a/README.md
+++ b/README.md
@@ -254,6 +254,15 @@ A few things at least you have to know about vim-over are:
 
 For more information, visit https://github.com/osyo-manga/vim-over or `:help over`.
 
+### vim-better-whitespace
+
+vim-better-whitespace is a plugin which causes all trailing whitespace characters (spaces and tabs) to be highlighted.
+
+A few things at least you have to know about vim-better-whitespace are:
+
+- `:ToggleWhitespace` : to toggle whitespace highlighting on/off (on by default)
+- `:StripWhitespace` : to clean all extra whitespaces
+
 ### ctrlp
 
 ctrlp is a full path fuzzy file etc finder for vim.


### PR DESCRIPTION
消し忘れると切ない trailing whitespace を色付けしてわかりやすくするためのプラグインを追加しました。

<img width="640" alt="2016-05-15 9 22 18" src="https://cloud.githubusercontent.com/assets/333180/15271371/643e4c02-1a80-11e6-91b6-1e38bdcf2fff.png">
