### PR TITLE
Neovim！

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -36,7 +36,11 @@ set title
 set laststatus=2
 
 " Register Settings
-set clipboard^=unnamed,unnamedplus
+if has('nvim')
+  set clipboard+=unnamedplus
+else
+  set clipboard^=unnamed,unnamedplus
+endif
 
 " Leader
 let mapleader = "\<Space>"

--- a/.vimrc
+++ b/.vimrc
@@ -139,6 +139,16 @@ Plug 'tomasr/molokai'
 Plug 'sjl/badwolf'
 Plug 'altercation/vim-colors-solarized'
 
+" Vim/Neovim specific plugins
+if has('nvim')
+  function! DoRemote(arg)
+    UpdateRemotePlugins
+  endfunction
+
+  Plug 'Shougo/deoplete.nvim', { 'do': function('DoRemote') }
+endif
+
+
 call plug#end()
 
 " }}}
@@ -227,6 +237,12 @@ nmap <silent> <Esc><Esc> :<C-u>nohlsearch<Return><Plug>(anzu-clear-search-status
 " vim-over
 nnoremap <silent> <Leader>s :<C-u>OverCommandLine<Return>
 xnoremap <silent> <Leader>s :<C-u>'<,'>OverCommandLine<Return>
+
+" Vim/Neovim specific plugin settings
+if has('nvim')
+  " deoplete.nvim
+  let g:deoplete#enable_at_startup = 1
+endif
 
 " }}}
 

--- a/.vimrc
+++ b/.vimrc
@@ -12,6 +12,11 @@ endif
 " ------------------------------------------------
 " {{{1
 
+" Define and re-initialize augroup for vimrc
+augroup vimrc
+  autocmd!
+augroup END
+
 syntax on
 filetype plugin indent on
 
@@ -106,7 +111,6 @@ Plug 'ctrlpvim/ctrlp.vim'
 Plug 'bling/vim-airline'
 Plug 'easymotion/vim-easymotion'
 Plug 'junegunn/vim-easy-align'
-Plug 'scrooloose/syntastic'
 Plug 'scrooloose/nerdtree', { 'on': 'NERDTreeToggle' } | Plug 'Xuyuanp/nerdtree-git-plugin', { 'on': 'NERDTreeToggle' }
 Plug 'airblade/vim-gitgutter'
 Plug 'jreybert/vimagit'
@@ -145,7 +149,10 @@ if has('nvim')
     UpdateRemotePlugins
   endfunction
 
+  Plug 'neomake/neomake'
   Plug 'Shougo/deoplete.nvim', { 'do': function('DoRemote') }
+else
+  Plug 'scrooloose/syntastic'
 endif
 
 
@@ -181,13 +188,6 @@ if executable('ag')
   let g:unite_source_grep_default_opts = '--nogroup --nocolor --column'
   let g:unite_source_grep_recursive_opt = ''
 endif
-
-" Syntastic
-let g:syntastic_check_on_open = 1
-let g:syntastic_check_on_wq = 0
-let g:syntastic_mode_map = { 'mode': 'passive', 'active_filetypes': ['ruby', 'python'] }
-let g:syntastic_ruby_checkers = ['rubocop', 'mri']
-let g:syntastic_python_checkers = ['flake8']
 
 " NERDTree
 nnoremap <silent> <Leader>nt :<C-u>NERDTreeToggle<Return>
@@ -240,8 +240,19 @@ xnoremap <silent> <Leader>s :<C-u>'<,'>OverCommandLine<Return>
 
 " Vim/Neovim specific plugin settings
 if has('nvim')
+  " neomake
+  autocmd vimrc BufEnter,BufWritePost * Neomake
+  let g:neomake_verbose = 0
+
   " deoplete.nvim
   let g:deoplete#enable_at_startup = 1
+else
+  " Syntastic
+  let g:syntastic_check_on_open = 1
+  let g:syntastic_check_on_wq = 0
+  let g:syntastic_mode_map = { 'mode': 'passive', 'active_filetypes': ['ruby', 'python'] }
+  let g:syntastic_ruby_checkers = ['rubocop', 'mri']
+  let g:syntastic_python_checkers = ['flake8']
 endif
 
 " }}}

--- a/.vimrc
+++ b/.vimrc
@@ -136,7 +136,7 @@ Plug 'pangloss/vim-javascript', { 'for': ['javascript', 'javascript.jsx'] } | Pl
 
 if get(g:, 'load_wakatime')
   Plug 'wakatime/vim-wakatime'
-end
+endif
 
 " Colorschemes
 Plug 'tomasr/molokai'
@@ -149,12 +149,14 @@ if has('nvim')
     UpdateRemotePlugins
   endfunction
 
-  Plug 'neomake/neomake'
   Plug 'Shougo/deoplete.nvim', { 'do': function('DoRemote') }
+endif
+
+if has('nvim') && get(g:, 'load_neomake')
+  Plug 'neomake/neomake'
 else
   Plug 'scrooloose/syntastic'
 endif
-
 
 call plug#end()
 
@@ -240,12 +242,14 @@ xnoremap <silent> <Leader>s :<C-u>'<,'>OverCommandLine<Return>
 
 " Vim/Neovim specific plugin settings
 if has('nvim')
+  " deoplete.nvim
+  let g:deoplete#enable_at_startup = 1
+endif
+
+if has('nvim') && get(g:, 'load_neomake')
   " neomake
   autocmd vimrc BufEnter,BufWritePost * Neomake
   let g:neomake_verbose = 0
-
-  " deoplete.nvim
-  let g:deoplete#enable_at_startup = 1
 else
   " Syntastic
   let g:syntastic_check_on_open = 1

--- a/.vimrc.preset.sample
+++ b/.vimrc.preset.sample
@@ -1,2 +1,5 @@
 " if you use vim-watatime, uncomment this line
 " let g:load_wakatime = 1
+
+" if you use Neovim and want to use Neomake rather than Syntastic, uncomment this line
+" let g:load_neomake = 1

--- a/README.md
+++ b/README.md
@@ -264,3 +264,9 @@ For more information, visit https://github.com/jgdavey/vim-blockle or `:help blo
 vim-wakatime is a plugin for [WakaTime](https://wakatime.com/). It requires to sign up WakaTime and input API key. If you want to use it, uncomment `let g:load_wakatime = 1` in `~/.vimrc.preset` .
 
 For more information, visit https://wakatime.com/help/plugins/vim
+
+### Neomake (only on Neovim)
+
+Neomake is a plugin for asynchronous `:make`. If you want to use it, uncomment `let g:load_neomake = 1` in `~/.vimrc.preset` .
+
+For more information, visit https://github.com/neomake/neomake


### PR DESCRIPTION
Neovim 用の設定をマージする PR です。Vim を使ってる人にはまったく影響ないです。
しばらく使ってみて問題なさそうなのでそろそろ master に取り込みたく。
- Neovim を使っている場合は deoplete.nvim プラグインが有効になる
- Neovim を使っていて、かつ `.vimrc.preset` で `let g:load_neomake = 1` のコメントを外した場合、Syntastic の代わりに Neomake が有効になる
- クリップボード設定が Neovim だとうまく動かないので修正
