### PR TITLE
CtrlP の高速化のためのオプションを追加

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -138,6 +138,10 @@ if get(g:, 'load_wakatime')
   Plug 'wakatime/vim-wakatime'
 endif
 
+if get(g:, 'load_cpsm')
+  Plug 'nixprime/cpsm', { 'do': 'bash install.sh' }
+endif
+
 " Colorschemes
 Plug 'tomasr/molokai'
 Plug 'sjl/badwolf'
@@ -206,8 +210,17 @@ nnoremap <silent> [rails]h :<C-u>Unite<Space>rails/helper<Return>
 " unite-outline
 nnoremap <silent> [unite]o :<C-u>Unite<Space>-vertical<Space>-no-quit<Space>-direction=botright<Space>-winwidth=35<Space>outline<Return>
 
-" ctrlp
-let g:ctrlp_user_command = ['.git/', 'git --git-dir=%s/.git ls-files -oc --exclude-standard']
+" CtrlP
+if get(g:, 'load_cpsm')
+  let g:ctrlp_match_func = { 'match': 'cpsm#CtrlPMatch' }
+endif
+
+if get(g:, 'ctrlp_use_files') && executable('files')
+  let g:ctrlp_user_command = 'files -a %s'
+else
+  let g:ctrlp_user_command = ['.git/', 'git --git-dir=%s/.git ls-files -oc --exclude-standard']
+endif
+
 let g:ctrlp_match_window = 'bottom,order:btt,min:3,max:15,results:15'
 let g:ctrlp_open_new_file = 'r'
 

--- a/.vimrc.preset.sample
+++ b/.vimrc.preset.sample
@@ -3,3 +3,11 @@
 
 " if you use Neovim and want to use Neomake rather than Syntastic, uncomment this line
 " let g:load_neomake = 1
+
+" if you want to use cpsm for CtrlP matcher, uncomment this line
+" (cpsm requires Vim compiled with the +python flag and C++ compiler supporting C++11)
+" let g:load_cpsm = 1
+
+" if you want to use files for CtrlP file listing, uncomment this line
+" (cpsm requires to install files)
+" let g:ctrlp_use_files = 1

--- a/README.md
+++ b/README.md
@@ -243,13 +243,18 @@ A few things at least you have to know about vim-better-whitespace are:
 - `:ToggleWhitespace` : to toggle whitespace highlighting on/off (on by default)
 - `:StripWhitespace` : to clean all extra whitespaces
 
-### ctrlp
+### CtrlP
 
-ctrlp is a full path fuzzy file etc finder for vim.
+CtrlP is a full path fuzzy file etc finder for vim.
 
 - `Ctrl + p` : open ctrlp, then show magaged files via git
 
 For more information, visit https://github.com/ctrlpvim/ctrlp.vim or `:help ctrlp`.
+
+**[Advanced]** Since CtrlP also provides the ways to customize matcher/file listup command, you can change them if you want by modifying `~/.vimrc.preset` .
+
+- if you want to use [cpsm](https://github.com/nixprime/cpsm) as the matcher, uncomment `let g:load_cpsm = 1`
+- if you want to use [files](https://github.com/mattn/files) for file listing, uncomment `let g:ctrlp_use_files = 1`
 
 ### vim-blockle
 


### PR DESCRIPTION
CtrlP の高速カスタマイズのためのオプションを追加しました。
かなり効果的ですが、C++ コンパイラや Go パッケージのインストールが必要なためにオプション扱いとしています。
- カスタムマッチャに [cpsm](https://github.com/nixprime/cpsm) が使える
- カスタムファイルリストコマンドに [files](https://github.com/mattn/files) を使える

この組み合わせだと相当数のファイルが対象になっても爆速なので、files を使う場合には git コマンドによる絞り込みもしないようにしています (つまりプロジェクトのディレクトリで git 管理下ではないものも対象にできる) 。
