### PR TITLE
neocomplete.vim を追加

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -154,6 +154,10 @@ if has('nvim')
   endfunction
 
   Plug 'Shougo/deoplete.nvim', { 'do': function('DoRemote') }
+else
+  if has('lua')
+    Plug 'Shougo/neocomplete.vim'
+  endif
 endif
 
 if has('nvim') && get(g:, 'load_neomake')
@@ -257,6 +261,11 @@ xnoremap <silent> <Leader>s :<C-u>'<,'>OverCommandLine<Return>
 if has('nvim')
   " deoplete.nvim
   let g:deoplete#enable_at_startup = 1
+else
+  if has('lua')
+    " neocomplete.vim
+    let g:neocomplete#enable_at_startup = 1
+  endif
 endif
 
 if has('nvim') && get(g:, 'load_neomake')


### PR DESCRIPTION
単語をキャッシュして自動的に補完候補にしてくれる neocomplete.vim を追加しました。

うざいと思う人もいるかもだし、パフォーマンスにも多少影響するので Neovim のときだけ deoplete.vim を有効にするようにしてましたが、やっぱり Vim でも欲しくなったので追加です。

Lua インターフェースが有効なときのみインストールされるようにしています。

特に設定不要で使えるので README の更新はなしです。
