### PR TITLE
[WIP] [EXPERIMENTAL] GNU GLOBAL (gtags) を試し中

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -107,6 +107,7 @@ Plug 'Shougo/neomru.vim'
 Plug 'Shougo/unite.vim'
 Plug 'basyura/unite-rails'
 Plug 'Shougo/unite-outline'
+Plug '5t111111/unite-gtags', { 'branch': 'gem-support' }
 Plug 'ctrlpvim/ctrlp.vim'
 Plug 'bling/vim-airline'
 Plug 'easymotion/vim-easymotion'
@@ -214,6 +215,19 @@ nnoremap <silent> [rails]h :<C-u>Unite<Space>rails/helper<Return>
 
 " unite-outline
 nnoremap <silent> [unite]o :<C-u>Unite<Space>-vertical<Space>-no-quit<Space>-direction=botright<Space>-winwidth=35<Space>outline<Return>
+
+" unite-gtags
+let g:unite_source_gtags_project_config = {
+      \   '_': {
+      \     'through_all_tags': 1
+      \   }
+      \ }
+
+nnoremap [gtags] <Nop>
+nmap     <Leader>t [gtags]
+nnoremap <silent> [gtags]t :<C-u>Unite<Space>gtags/context<Return>
+nnoremap <silent> [gtags]d :<C-u>Unite<Space>gtags/def<Return>
+nnoremap <silent> [gtags]r :<C-u>Unite<Space>gtags/ref<Return>
 
 " CtrlP
 if get(g:, 'load_cpsm')


### PR DESCRIPTION
Ruby だと 精度は低いですが、gtags でタグジャンプができるようにするのを試してみています。興味ある人は試してみてくれると嬉しいです。

unite-gtags を fork して依存 gem もタグの探索対象にしてみました。
## 依存パッケージ
- GLOBAL
- Pygments

*多分 `brew install global` でどっちも入ります。
## 事前準備

↓をやってください。

http://qiita.com/5t111111/items/5e854f6047d187ea21c7#アプリケーションコードのタグを生成する
http://qiita.com/5t111111/items/5e854f6047d187ea21c7#gem-のタグを生成する
## 使う

とりあえずコードのメソッド名とかの上で `<Space> t t` としてみると、定義か参照にジャンプします。
## 既知の問題

`present?` とか `save!` みたいに記号を含むメソッドは Vim の `<cword>` で正しく拾えないっぽくて見つけられない？
