### PR TITLE
Ruby のファイルでは ! と ? を単語に含めるように設定

### DIFF
--- a/.vim/after/ftplugin/ruby.vim
+++ b/.vim/after/ftplugin/ruby.vim
@@ -7,6 +7,7 @@ setlocal expandtab
 setlocal tabstop=2
 setlocal shiftwidth=2
 setlocal softtabstop=0
+setlocal iskeyword+=!,?
 
 " Convert to new Hash syntax
 nnoremap <Leader><Leader>rh :<C-u>%s/:\([^ ]*\)\(\s*\)=>/\1:/g<Return>


### PR DESCRIPTION
Ruby ではメソッド名に ! / ? が含まれることが多いので、単語選択でそこだけ除外されると面倒です。
そこで、! / ? も含めるようにしました。
