### PR TITLE
vim-migemo を追加

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -133,6 +133,7 @@ Plug 'neovimhaskell/haskell-vim', { 'for': ['haskell', 'cabal'] }
 Plug 'elixir-lang/vim-elixir', { 'for': 'elixir' }
 Plug 'rhysd/vim-crystal', { 'for': 'crystal' }
 Plug 'pangloss/vim-javascript', { 'for': ['javascript', 'javascript.jsx'] } | Plug 'mxw/vim-jsx', { 'for': 'javascript.jsx' }
+Plug 'haya14busa/vim-migemo'
 
 if get(g:, 'load_wakatime')
   Plug 'wakatime/vim-wakatime'
@@ -256,6 +257,9 @@ nmap <silent> <Esc><Esc> :<C-u>nohlsearch<Return><Plug>(anzu-clear-search-status
 " vim-over
 nnoremap <silent> <Leader>s :<C-u>OverCommandLine<Return>
 xnoremap <silent> <Leader>s :<C-u>'<,'>OverCommandLine<Return>
+
+" vim-migemo
+nmap <silent> g/ <Plug>(migemo-migemosearch)
 
 " Vim/Neovim specific plugin settings
 if has('nvim')

--- a/README.md
+++ b/README.md
@@ -270,6 +270,15 @@ vim-wakatime is a plugin for [WakaTime](https://wakatime.com/). It requires to s
 
 For more information, visit https://wakatime.com/help/plugins/vim
 
+### vim-migemo
+
+vim-migemo is a plugin for [migemo (cmigemo)](http://www.kaoriya.net/software/cmigemo/) search. It requires cmigemo (When using OS X, you can install it via `brew install cmigemo`.
+
+- `g/` or `<Leader>mi` to start migemo search
+- You can search a word with "Okurigana" by using upper characters (e.g. 'jikkouSuru' for '実行する')
+
+For more information, visit https://github.com/haya14busa/vim-migemo
+
 ### Neomake (only on Neovim)
 
 Neomake is a plugin for asynchronous `:make`. If you want to use it, uncomment `let g:load_neomake = 1` in `~/.vimrc.preset` .


### PR DESCRIPTION
Migemo を使いたかったので追加しました。超便利。

通常の検索から透過的に利用出来る https://github.com/rhysd/migemo-search.vim も試したのですが、やっぱり明示的に Migemo を指定できた方が便利なのと、送り仮名判定などができなそうだったのでこちらにしています。
