### PR TITLE
Denite.vim を追加

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -234,9 +234,9 @@ if get(g:, 'load_denite')
   if executable('ag')
     call denite#custom#var('grep', 'command', ['ag'])
     call denite#custom#var('grep', 'default_opts',
-                    \ ['--follow', '--nogroup', '--nocolor', '--column'])
+                    \ ['-i', '--vimgrep'])
     call denite#custom#var('grep', 'recursive_opts', [])
-    call denite#custom#var('grep', 'pattern_opt', ['--match'])
+    call denite#custom#var('grep', 'pattern_opt', [])
     call denite#custom#var('grep', 'separator', ['--'])
     call denite#custom#var('grep', 'final_opts', [])
   endif

--- a/.vimrc
+++ b/.vimrc
@@ -143,7 +143,7 @@ if get(g:, 'load_wakatime')
 endif
 
 if get(g:, 'load_cpsm')
-  Plug 'nixprime/cpsm', { 'do': 'bash install.sh' }
+  Plug 'nixprime/cpsm', { 'do': 'env PY3=ON ./install.sh' }
 endif
 
 if get(g:, 'load_vimwiki')
@@ -163,6 +163,7 @@ if has('nvim')
   endfunction
 
   Plug 'Shougo/deoplete.nvim', { 'do': function('DoRemote') }
+  Plug 'Shougo/denite.nvim', { 'do': function('DoRemote') }
 else
   if has('lua')
     Plug 'Shougo/neocomplete.vim'
@@ -233,6 +234,12 @@ nnoremap <silent> [unite]o :<C-u>Unite<Space>-vertical<Space>-no-quit<Space>-dir
 " CtrlP
 if get(g:, 'load_cpsm')
   let g:ctrlp_match_func = { 'match': 'cpsm#CtrlPMatch' }
+
+
+  if has('nvim')
+    " Denite.vim integration
+    call denite#custom#source('file_rec', 'matcher', ['matcher_cpsm'])
+  endif
 endif
 
 let g:ctrlp_user_command = {
@@ -280,6 +287,12 @@ nmap <silent> g/ <Plug>(migemo-migemosearch)
 if has('nvim')
   " deoplete.nvim
   let g:deoplete#enable_at_startup = 1
+
+  " Denite.vim
+  nnoremap <silent> [unite]r :<C-u>Denite<Space>file_mru<Return>
+  nnoremap <silent> [unite]fp :<C-u>Denite<Space>file_rec<Return>
+  nnoremap <silent> [unite]gp :<C-u>Denite<Space>grep<Return>
+  nnoremap <silent> [unite]l :<C-u>Denite<Space>line<Return>
 else
   if has('lua')
     " neocomplete.vim

--- a/.vimrc
+++ b/.vimrc
@@ -150,6 +150,18 @@ if get(g:, 'load_vimwiki')
   Plug 'vimwiki/vimwiki'
 endif
 
+if get(g:, 'load_denite')
+  if !has('nvim')
+    Plug 'Shougo/denite.nvim'
+  endif
+endif
+
+if get(g:, 'load_syntastic')
+  Plug 'scrooloose/syntastic'
+else
+  Plug 'neomake/neomake'
+endif
+
 " Colorschemes
 Plug 'tomasr/molokai'
 Plug 'sjl/badwolf'
@@ -163,17 +175,14 @@ if has('nvim')
   endfunction
 
   Plug 'Shougo/deoplete.nvim', { 'do': function('DoRemote') }
-  Plug 'Shougo/denite.nvim', { 'do': function('DoRemote') }
+
+  if get(g:, 'load_denite')
+    Plug 'Shougo/denite.nvim', { 'do': function('DoRemote') }
+  endif
 else
   if has('lua')
     Plug 'Shougo/neocomplete.vim'
   endif
-endif
-
-if get(g:, 'load_syntastic')
-  Plug 'scrooloose/syntastic'
-else
-  Plug 'neomake/neomake'
 endif
 
 call plug#end()
@@ -209,6 +218,28 @@ if executable('ag')
   let g:unite_source_grep_recursive_opt = ''
 endif
 
+" Denite.vim
+if get(g:, 'load_denite')
+  nnoremap <silent> [unite]r :<C-u>Denite<Space>file_mru<Return>
+  nnoremap <silent> [unite]fp :<C-u>Denite<Space>file_rec<Return>
+  nnoremap <silent> [unite]gp :<C-u>Denite<Space>grep<Return>
+  nnoremap <silent> [unite]l :<C-u>Denite<Space>line<Return>
+  nnoremap <silent> [unite]u :<C-u>Denite<Space>-resume<Return>
+
+  call denite#custom#map('insert', '<C-j>', 'move_to_next_line')
+  call denite#custom#map('insert', '<C-k>', 'move_to_prev_line')
+  call denite#custom#map('insert', '<C-x>', 'input_command_line')
+
+  " Use 'ag' instead of 'grep' if available
+  if executable('ag')
+    call denite#custom#var('grep', 'command', ['ag'])
+    call denite#custom#var('grep', 'recursive_opts', [])
+    call denite#custom#var('grep', 'final_opts', [])
+    call denite#custom#var('grep', 'separator', [])
+    call denite#custom#var('grep', 'default_opts', ['--follow', '--nogroup', '--nocolor', '--column'])
+  endif
+endif
+
 " Neosnippet
 imap <C-k> <Plug>(neosnippet_expand_or_jump)
 smap <C-k> <Plug>(neosnippet_expand_or_jump)
@@ -235,9 +266,8 @@ nnoremap <silent> [unite]o :<C-u>Unite<Space>-vertical<Space>-no-quit<Space>-dir
 if get(g:, 'load_cpsm')
   let g:ctrlp_match_func = { 'match': 'cpsm#CtrlPMatch' }
 
-
-  if has('nvim')
-    " Denite.vim integration
+  " Denite.vim integration
+  if get(g:, 'load_denite')
     call denite#custom#source('file_rec', 'matcher', ['matcher_cpsm'])
   endif
 endif
@@ -287,12 +317,6 @@ nmap <silent> g/ <Plug>(migemo-migemosearch)
 if has('nvim')
   " deoplete.nvim
   let g:deoplete#enable_at_startup = 1
-
-  " Denite.vim
-  nnoremap <silent> [unite]r :<C-u>Denite<Space>file_mru<Return>
-  nnoremap <silent> [unite]fp :<C-u>Denite<Space>file_rec<Return>
-  nnoremap <silent> [unite]gp :<C-u>Denite<Space>grep<Return>
-  nnoremap <silent> [unite]l :<C-u>Denite<Space>line<Return>
 else
   if has('lua')
     " neocomplete.vim

--- a/.vimrc
+++ b/.vimrc
@@ -233,10 +233,12 @@ if get(g:, 'load_denite')
   " Use 'ag' instead of 'grep' if available
   if executable('ag')
     call denite#custom#var('grep', 'command', ['ag'])
+    call denite#custom#var('grep', 'default_opts',
+                    \ ['--follow', '--nogroup', '--nocolor', '--column'])
     call denite#custom#var('grep', 'recursive_opts', [])
+    call denite#custom#var('grep', 'pattern_opt', ['--match'])
+    call denite#custom#var('grep', 'separator', ['--'])
     call denite#custom#var('grep', 'final_opts', [])
-    call denite#custom#var('grep', 'separator', [])
-    call denite#custom#var('grep', 'default_opts', ['--follow', '--nogroup', '--nocolor', '--column'])
   endif
 endif
 

--- a/.vimrc
+++ b/.vimrc
@@ -226,9 +226,9 @@ if get(g:, 'load_denite')
   nnoremap <silent> [unite]l :<C-u>Denite<Space>line<Return>
   nnoremap <silent> [unite]u :<C-u>Denite<Space>-resume<Return>
 
-  call denite#custom#map('insert', '<C-j>', 'move_to_next_line')
-  call denite#custom#map('insert', '<C-k>', 'move_to_prev_line')
-  call denite#custom#map('insert', '<C-x>', 'input_command_line')
+  call denite#custom#map('insert', '<C-j>', '<denite:move_to_next_line>', 'noremap')
+  call denite#custom#map('insert', '<C-k>', '<denite:move_to_previous_line>', 'noremap')
+  call denite#custom#map('insert', '<C-x>', '<denite:input_command_line>', 'noremap')
 
   " Use 'ag' instead of 'grep' if available
   if executable('ag')

--- a/.vimrc
+++ b/.vimrc
@@ -221,6 +221,7 @@ endif
 " Denite.vim
 if get(g:, 'load_denite')
   nnoremap <silent> [unite]r :<C-u>Denite<Space>file_mru<Return>
+  nnoremap <silent> [unite]b :<C-u>Denite<Space>buffer<Return>
   nnoremap <silent> [unite]fp :<C-u>Denite<Space>file_rec<Return>
   nnoremap <silent> [unite]gp :<C-u>Denite<Space>grep<Return>
   nnoremap <silent> [unite]l :<C-u>Denite<Space>line<Return>

--- a/.vimrc.preset.sample
+++ b/.vimrc.preset.sample
@@ -10,4 +10,4 @@
 
 " if you want to use Denite, uncomment this line
 " (Some features using Unite are overwritten, but others remain active)
-let g:load_denite = 1
+" let g:load_denite = 1

--- a/.vimrc.preset.sample
+++ b/.vimrc.preset.sample
@@ -7,3 +7,7 @@
 " if you want to use cpsm for CtrlP matcher, uncomment this line
 " (cpsm requires Vim compiled with the +python flag and C++ compiler supporting C++11)
 " let g:load_cpsm = 1
+
+" if you want to use Denite, uncomment this line
+" (Some features using Unite are overwritten, but others remain active)
+let g:load_denite = 1

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ A few things at least you have to know about Unite are:
 - `<Leader>ub` : to "unite" buffers
 - `<Leader>ufp` : to "unite" find files in the project (e.g. for files in git repository)
 - `<Leader>ugp` : to "unite" grep files in the project (e.g. from files in git repository)
+  - ag will be used as grep source if available
 
 For more information, visit https://github.com/Shougo/unite.vim or `:help unite`.
 
@@ -102,6 +103,29 @@ unite-outline is a unite plugin for current buffer outline view.
 - `<Leader>uo` : to "unite" outline into right window which is not close.
 
 For more information, visit https://github.com/Shougo/unite-outline or `:help unite-outline`.
+
+### Denite.nvim
+
+Denite.nvim is to unite all interfaces for NeoVim/Vim. Maybe Unite will be replaced with Denite in near future
+because the plugin author of Unite states that active development of Unite has stopped.
+
+However, for the moment Denite.vim is an optional choice as it does not have enough sources (like unite-rails)
+and maybe still has many breaking changes, so you have to explicitly configure your `~/.vimrc.preset` by
+uncommenting `let g:load_denite = 1`.
+
+A few things at least you have to know about Denite are:
+
+- It requires Neovim or Vim 8.0+ with if_python3
+- `<C-j>` : to move to next line
+- `<C-k>` : to move to previous line
+- `<Leader>ur` : to "denite" recently opened files
+- `<Leader>ub` : to "denite" buffers
+- `<Leader>ufp` : to "denite" find files in the project (e.g. for files in git repository)
+  - It is alomost the same as CtrlP
+- `<Leader>ugp` : to "denite" grep files in the project (e.g. from files in git repository)
+  - ag will be used as grep source if available
+
+For more information, visit https://github.com/Shougo/denite.nvim or `:help denite`.
 
 ### easymotion
 


### PR DESCRIPTION
先日公開されたばかりの Denite.vim (Unite.vim の後継) を追加しました。

今の時点ではコード量も少ないし、かなりの部分が Python で書かれていて読みやすいので、開発をウォッチしながら使ってみるのも面白いと思います。

Denite.vim 自体は Vim 8 の job/async を使って Vim にも対応しているようですが、このブランチではとりあえず Neovim でだけ動作するようにしています。
