### PR TITLE
filesをctrlpのリストアップ用に使っている場合でも git ls-files を使うように設定

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -222,11 +222,7 @@ if get(g:, 'load_cpsm')
   let g:ctrlp_match_func = { 'match': 'cpsm#CtrlPMatch' }
 endif
 
-if get(g:, 'ctrlp_use_files') && executable('files')
-  let g:ctrlp_user_command = 'files -a %s'
-else
-  let g:ctrlp_user_command = ['.git/', 'git --git-dir=%s/.git ls-files -oc --exclude-standard']
-endif
+let g:ctrlp_user_command = ['.git/', 'git --git-dir=%s/.git ls-files -oc --exclude-standard']
 
 let g:ctrlp_match_window = 'bottom,order:btt,min:3,max:15,results:15'
 let g:ctrlp_open_new_file = 'r'

--- a/.vimrc
+++ b/.vimrc
@@ -222,8 +222,12 @@ if get(g:, 'load_cpsm')
   let g:ctrlp_match_func = { 'match': 'cpsm#CtrlPMatch' }
 endif
 
-let g:ctrlp_user_command = ['.git/', 'git --git-dir=%s/.git ls-files -oc --exclude-standard']
-
+let g:ctrlp_user_command = {
+  \ 'types': {
+    \ 1: ['.git', 'git -C %s ls-files --cached --exclude-standard --others'],
+    \ },
+  \ 'fallback': 'find %s -type f'
+  \ }
 let g:ctrlp_match_window = 'bottom,order:btt,min:3,max:15,results:15'
 let g:ctrlp_open_new_file = 'r'
 


### PR DESCRIPTION
files を使うとすごく早いので全ファイルを対象にしていましたが、git 管理下以外のファイルはどうせほとんど対象にしないので挙動を files なしのものと合わせました。

ついでに、ctrlp_user_command の記法を少し詳しくしました。たぶん git 以外を使うことはないかもですが、将来的に複数のタイプに対応しやすいようにもしてあります。

挙動は変わりません。