### PR TITLE
CtrlP の files 連携箇所を一旦すべて削除

### DIFF
--- a/.vimrc.preset.sample
+++ b/.vimrc.preset.sample
@@ -7,7 +7,3 @@
 " if you want to use cpsm for CtrlP matcher, uncomment this line
 " (cpsm requires Vim compiled with the +python flag and C++ compiler supporting C++11)
 " let g:load_cpsm = 1
-
-" if you want to use files for CtrlP file listing, uncomment this line
-" (cpsm requires to install files)
-" let g:ctrlp_use_files = 1

--- a/README.md
+++ b/README.md
@@ -248,14 +248,13 @@ A few things at least you have to know about vim-better-whitespace are:
 
 CtrlP is a full path fuzzy file etc finder for vim.
 
-- `Ctrl + p` : open ctrlp, then show magaged files via git
+- `Ctrl + p` : open ctrlp, then show magaged files via `git ls-files`
 
 For more information, visit https://github.com/ctrlpvim/ctrlp.vim or `:help ctrlp`.
 
 **[Advanced]** Since CtrlP also provides the ways to customize matcher/file listup command, you can change them if you want by modifying `~/.vimrc.preset` .
 
 - if you want to use [cpsm](https://github.com/nixprime/cpsm) as the matcher, uncomment `let g:load_cpsm = 1`
-- if you want to use [files](https://github.com/mattn/files) for file listing, uncomment `let g:ctrlp_use_files = 1`
 
 ### vim-blockle
 


### PR DESCRIPTION
以下の理由より、一旦 files の連携をすべて削除しました。

- files を使う設定でも Git リポジトリでは `git ls-files` を使うようにした (#27)
- ベンチマークしたら files の同期的実行より BSD find の方が倍くらい高速 (macOS 10.12.1 で確認)
- files の非同期実行だと find より速くなるが、ファイル数によっては結果が正しくないことがある
- どんどん機能追加していく方向だとメンテが大変になるので整理しながらいきたい

Windows 環境とかだと files が便利な場面もあるかもですが、一旦現時点では上記より外した方がいいかなと判断しました。