### PR TITLE
Neomake を Neovim だけでなく Vim でも使えるようにしました

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -163,10 +163,10 @@ else
   endif
 endif
 
-if get(g:, 'load_neomake')
-  Plug 'neomake/neomake'
-else
+if get(g:, 'load_syntastic')
   Plug 'scrooloose/syntastic'
+else
+  Plug 'neomake/neomake'
 endif
 
 call plug#end()
@@ -274,17 +274,17 @@ else
   endif
 endif
 
-if get(g:, 'load_neomake')
-  " neomake
-  autocmd vimrc BufEnter,BufWritePost * Neomake
-  let g:neomake_verbose = 0
-else
+if get(g:, 'load_syntastic')
   " Syntastic
   let g:syntastic_check_on_open = 1
   let g:syntastic_check_on_wq = 0
   let g:syntastic_mode_map = { 'mode': 'passive', 'active_filetypes': ['ruby', 'python'] }
   let g:syntastic_ruby_checkers = ['rubocop', 'mri']
   let g:syntastic_python_checkers = ['flake8']
+else
+  " neomake
+  autocmd vimrc BufEnter,BufWritePost * Neomake
+  let g:neomake_verbose = 0
 endif
 
 " }}}

--- a/.vimrc
+++ b/.vimrc
@@ -163,7 +163,7 @@ else
   endif
 endif
 
-if has('nvim') && get(g:, 'load_neomake')
+if get(g:, 'load_neomake')
   Plug 'neomake/neomake'
 else
   Plug 'scrooloose/syntastic'
@@ -274,7 +274,7 @@ else
   endif
 endif
 
-if has('nvim') && get(g:, 'load_neomake')
+if get(g:, 'load_neomake')
   " neomake
   autocmd vimrc BufEnter,BufWritePost * Neomake
   let g:neomake_verbose = 0

--- a/.vimrc.preset.sample
+++ b/.vimrc.preset.sample
@@ -1,8 +1,8 @@
 " if you use vim-watatime, uncomment this line
 " let g:load_wakatime = 1
 
-" if you want to use Neomake rather than Syntastic, uncomment this line
-" let g:load_neomake = 1
+" if you want to use Syntastic rather than Neomake, uncomment this line
+" let g:load_syntastic = 1
 
 " if you want to use cpsm for CtrlP matcher, uncomment this line
 " (cpsm requires Vim compiled with the +python flag and C++ compiler supporting C++11)

--- a/.vimrc.preset.sample
+++ b/.vimrc.preset.sample
@@ -1,7 +1,7 @@
 " if you use vim-watatime, uncomment this line
 " let g:load_wakatime = 1
 
-" if you use Neovim and want to use Neomake rather than Syntastic, uncomment this line
+" if you want to use Neomake rather than Syntastic, uncomment this line
 " let g:load_neomake = 1
 
 " if you want to use cpsm for CtrlP matcher, uncomment this line

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ For more information, visit https://github.com/haya14busa/vim-migemo
 
 ### Neomake
 
-Neomake is a plugin for asynchronous `:make`, and you can use it as an alternative async option to Syntastic. If you want to use it, uncomment `let g:load_neomake = 1` in `~/.vimrc.preset` .
+Neomake is a plugin for asynchronous `:make`.
 
 Although Neomake has quite a few builtin configuration by default (including `rubocop`), you are also able to add a specific maker in accordance with its file type. Say if you want to use `eslint` on the `javascritpt` files, you can add the following lines to `~/.vimrc.local`:
 
@@ -289,7 +289,13 @@ Although Neomake has quite a few builtin configuration by default (including `ru
 let g:neomake_javascript_enabled_makers = ['eslint']
 ```
 
-For more information, visit https://github.com/neomake/neomake
+For more information, visit https://github.com/neomake/neomake or `:help neomake`.
+
+### Syntastic
+
+Syntastic is a syntax checking plugin. You can use it as an alternative option to static code analysis plugin (Neomake by default). If you want to use it, uncomment `let g:load_synstastic = 1` in `~/.vimrc.preset` .
+
+For more information, visit https://github.com/vim-syntastic/syntastic or `:help syntastic`.
 
 ### vim-surround
 

--- a/README.md
+++ b/README.md
@@ -279,9 +279,15 @@ vim-migemo is a plugin for [migemo (cmigemo)](http://www.kaoriya.net/software/cm
 
 For more information, visit https://github.com/haya14busa/vim-migemo
 
-### Neomake (only on Neovim)
+### Neomake
 
-Neomake is a plugin for asynchronous `:make`. If you want to use it, uncomment `let g:load_neomake = 1` in `~/.vimrc.preset` .
+Neomake is a plugin for asynchronous `:make`, and you can use it as an alternative async option to Syntastic. If you want to use it, uncomment `let g:load_neomake = 1` in `~/.vimrc.preset` .
+
+Although Neomake has quite a few builtin configuration by default (including `rubocop`), you are also able to add a specific maker in accordance with its file type. Say if you want to use `eslint` on the `javascritpt` files, you can add the following lines to `~/.vimrc.local`:
+
+```vim
+let g:neomake_javascript_enabled_makers = ['eslint']
+```
 
 For more information, visit https://github.com/neomake/neomake
 


### PR DESCRIPTION
Neomake が neovim ではなく Vim でも問題なく動作するようになったので、Vim でも  Syntastic の代わりに Neomake を使うようにしました。

今まで通りに Syntastic を使いたければ、`let g:load_syntastic = 1` を `~/.vimrc.preset` に追加してください。

Ruby のファイル開くときとか保存するときに同機的なチェックが入って遅い！って人はめちゃめちゃ快適になると思います。
