### PR TITLE
bPrevious/bNext の <C-h>/<C-l> のキーマッピングを削除

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -78,10 +78,6 @@ nnoremap k gk
 nnoremap gj j
 nnoremap gk k
 
-" Previous/next buffer
-nnoremap <silent> <C-h> :<C-u>bprevious<Return>
-nnoremap <silent> <C-l> :<C-u>bNext<Return>
-
 " The drill sergeant says "DON'T USE CURSOR KEYS, USE HJKL"
 nnoremap <Left> :echoe<Space>"Use h"<Return>
 nnoremap <Right> :echoe<Space>"Use l"<Return>


### PR DESCRIPTION
- `<C-h>` に `:bPrevious`
- `<C-l>` に `: bNext`

のキーマッピングを設定していたんですけど、自分は全く使ってなくてたまに暴発して「うわー」ってなるので外したいです。

`<C-h>`, `<C-l>` は一応元々割り当てられたデフォルトのキーバインドがありますし、上書きするとしてもかなりファーストクラスな位置にいて押しやすいのでもっと利用頻度の高いものにしたいなという気持ちもあります。

確かこれは、一番最初にこの .vimrc 作ったときにいろんな人の設定を参考にしながら追加したやつです。

使ってる方います？いるなら残します。