### PR TITLE
bufferの切り替えにカーソルキーを割りあてる

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -78,9 +78,11 @@ nnoremap k gk
 nnoremap gj j
 nnoremap gk k
 
+" Switch buffer "DON'T USE CURSOR KEYS, USE HJKL"
+nnoremap <Left> :<C-u>bprevious<Return>
+nnoremap <Right> :<C-u>bNext<Return>
+
 " The drill sergeant says "DON'T USE CURSOR KEYS, USE HJKL"
-nnoremap <Left> :echoe<Space>"Use h"<Return>
-nnoremap <Right> :echoe<Space>"Use l"<Return>
 nnoremap <Up> :echoe<Space>"Use k"<Return>
 nnoremap <Down> :echoe<Space>"Use j"<Return>
 


### PR DESCRIPTION
カーソルキーはカーソル移動に使わない方針だったのでbufferの切り替え用に利用しています。bufferを使っている分には便利に感じることが多いのでPRにしてみました。