### PR TITLE
Add wildmode settings

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -40,6 +40,10 @@ set backspace=indent,eol,start
 set title
 set laststatus=2
 
+" Wildmode settings for Zsh like completion
+set wildmenu
+set wildmode=longest,full
+
 " Register Settings
 if has('nvim')
   set clipboard+=unnamedplus


### PR DESCRIPTION
See https://github.com/yochiyochirb/practical-vim/issues/6

本にある通りだと `set wildmode=full` だったのですが、
いくつか調べてみて、まず最長コマンド行で補完をしてくれた方が使い易い感じだったしこの設定している人が多そうだったので `set wildmode=longest,full` にしました。

