### PR TITLE
Go の filetype の設定を追加

### DIFF
--- a/.vim/after/ftplugin/go.vim
+++ b/.vim/after/ftplugin/go.vim
@@ -1,0 +1,7 @@
+if exists('b:did_ftplugin_go')
+  finish
+endif
+let b:did_ftplugin_go = 1
+
+setlocal tabstop=4
+setlocal shiftwidth=4


### PR DESCRIPTION
#39 で vim-go プラグインを追加しましたが、インデント幅などは設定されないので設定しました。
(デフォルトの8タブのハードタブは強烈に横長になる…)