### PR TITLE
Add configuration to enable vimwiki

### DIFF
--- a/.vimrc.preset.sample
+++ b/.vimrc.preset.sample
@@ -11,3 +11,6 @@
 " if you want to use Denite, uncomment this line
 " (Some features using Unite are overwritten, but others remain active)
 " let g:load_denite = 1
+
+" if you want to use vimwiki, uncomment this line
+" let g:load_vimwiki = 1

--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ For more information, visit https://github.com/Shougo/neosnippet.vim or `:help n
 ### vimwiki
 
 vimwiki constructs wiki in local. Default dir for wiki is `~/vimwiki` and file extension is markdown in this setting.
+If you want to use vimwiki, uncomment `let g:load_vimwiki = 1` in `~/.vimrc.preset` .
 
 - `<Leader>ww`: Open wiki home `~/vimwiki/index.md`
 


### PR DESCRIPTION
https://github.com/yochiyochirb/vimrc/pull/37 で vimwiki を追加していますが、有効化するための設定がなかったので追加しました。