### PR TITLE
Add gitv

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -131,6 +131,7 @@ Plug 'tpope/vim-surround'
 Plug 'tpope/vim-endwise', { 'for': 'ruby' }
 Plug 'tpope/vim-cucumber', { 'for': 'cucumber' }
 Plug 'tpope/vim-rails'
+Plug 'gregsexton/gitv', { 'on': 'Gitv' }
 Plug 'jgdavey/vim-blockle', { 'for': 'ruby' }
 Plug 'slim-template/vim-slim', { 'for': 'slim' }
 Plug 'kchmck/vim-coffee-script', { 'for': 'coffee' }


### PR DESCRIPTION
`git log` を Vim でシームレスに見られるように gitv を追加しました。
`:Gitv` で使います。
READMEに書こうと思いましたが、そもそも fugitive も何も書いてないのでとりあえずスルー