### PR TITLE
vimagit を削除

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -117,7 +117,6 @@ Plug 'easymotion/vim-easymotion'
 Plug 'junegunn/vim-easy-align'
 Plug 'scrooloose/nerdtree', { 'on': 'NERDTreeToggle' } | Plug 'Xuyuanp/nerdtree-git-plugin', { 'on': 'NERDTreeToggle' }
 Plug 'airblade/vim-gitgutter'
-Plug 'jreybert/vimagit'
 Plug 'godlygeek/tabular', { 'for': 'markdown' } | Plug 'plasticboy/vim-markdown', { 'for': 'markdown' }
 Plug 'kannokanno/previm', { 'for': 'markdown' }
 Plug 'tyru/open-browser.vim'
@@ -315,10 +314,6 @@ let g:EasyMotion_smartcase = 1
 " vim-easy-align
 xmap ga <Plug>(EasyAlign)
 nmap ga <Plug>(EasyAlign)
-
-" vimagit
-let g:magit_default_show_all_files = 2
-let g:magit_default_fold_level = 2
 
 " vim-markdown
 let g:vim_markdown_folding_disabled = 1

--- a/README.md
+++ b/README.md
@@ -240,19 +240,6 @@ A few things at least you have to know about NERDTree are:
 
 For more information, visit https://github.com/scrooloose/nerdtree or `:help NERDTree`.
 
-### vimagit
-
-vimagit is a new way to use git within vim.
-
-A few things at least you have to know about vimagit are:
-
-- `<Leader>M` : to open vimagit
-- `N` : to go to next hunk
-- `S` : to add file/hunk to stage
-- `CC` : to commit staged file/hunk, `CC` again for committing after writing commit message
-
-For more information, visit https://github.com/jreybert/vimagit or `:help vimagit`.
-
 ### previm
 
 previm is a plugin for Realtime preview (Markdown only for the moment).


### PR DESCRIPTION
vimagit たぶん誰も使ってないですよね…？
Emacs の magit みたく使えることを期待したんですが、ちょっと重たすぎるのもあって使っていないのでもう消しちゃいたいです。