### PR TITLE
gitv の diff の配色を変更

### DIFF
--- a/.vim/after/ftplugin/gitv.vim
+++ b/.vim/after/ftplugin/gitv.vim
@@ -1,0 +1,7 @@
+if exists('b:did_ftplugin_gitv')
+  finish
+endif
+let b:did_ftplugin_gitv = 1
+
+highlight diffAdded ctermfg=green
+highlight diffRemoved ctermfg=red


### PR DESCRIPTION
#48 で gitv を追加したけど、diff 見たときの配色がなかなかいけてない感じだったので専用の ft に対して調整しました。

### before

<img width="1552" alt="screen shot 2017-04-21 at 13 41 12" src="https://cloud.githubusercontent.com/assets/333180/25263162/89a3c16e-2698-11e7-8d5a-693ed80b383f.png">


### after

<img width="1552" alt="screen shot 2017-04-21 at 13 38 38" src="https://cloud.githubusercontent.com/assets/333180/25263168/946bc4fc-2698-11e7-8efd-bc2161ab723a.png">
