### PR TITLE
HTML のファイルタイプ設定を追加

### DIFF
--- a/.vim/after/ftplugin/html.vim
+++ b/.vim/after/ftplugin/html.vim
@@ -1,0 +1,9 @@
+if exists('b:did_ftplugin_html')
+  finish
+endif
+let b:did_ftplugin_html = 1
+
+setlocal expandtab
+setlocal tabstop=2
+setlocal shiftwidth=2
+setlocal softtabstop=0

--- a/README.md
+++ b/README.md
@@ -70,6 +70,23 @@ colorscheme molokai
 
 See the website for each colorscheme for details.
 
+### Indentation
+
+Indent styles for major filetypes are defined in `.vim/after/ftplugin`. When you don't like them and want to change them, it's the recommended way to overwrite them in `.vimrc.local` instead of directly modify these files:
+
+e.g.)
+
+If you want to change HTML indent size from 2 spaces to 4 spaces, add the following to `.vimrc.local`:
+
+```vim
+augroup HTML
+  autocmd!
+  autocmd FileType html set tabstop=4
+  autocmd FileType html set shiftwidth=4
+  autocmd FileType html set softtabstop=4
+augroup END
+```
+
 ### vim-airline
 
 vim-airline provides nice looking status line. Visit https://github.com/vim-airline/vim-airline for details.


### PR DESCRIPTION
HTML のインデントサイズなどはこれといった標準がなくプロジェクトや好みによって変わると思ったのであえて入れていませんでしたが、ぶっちゃけ不便なので追加しました。

スペース2タプで入れています。

合わせて、変更したいときのために直接ファイルをいじるのではなく `vimrc.local` で可能な変更方法を readme に追加しました。