### PR TITLE
Typescript の設定を追加

### DIFF
--- a/.vim/after/ftplugin/typescript.vim
+++ b/.vim/after/ftplugin/typescript.vim
@@ -1,0 +1,9 @@
+if exists('b:did_ftplugin_typescript')
+  finish
+endif
+let b:did_ftplugin_typescript = 1
+
+setlocal expandtab
+setlocal tabstop=2
+setlocal shiftwidth=2
+setlocal softtabstop=0

--- a/.vimrc
+++ b/.vimrc
@@ -369,10 +369,8 @@ endif
 
 " tsuquyomi
 let g:tsuquyomi_completion_detail = 1
-augroup tsuquyomi_specific
-  autocmd!
-  autocmd FileType typescript map <buffer> <C-\> <Plug>(TsuquyomiGoBack)
-augroup END
+let g:tsuquyomi_disable_quickfix = 1
+autocmd FileType typescript map <buffer> <C-\> <Plug>(TsuquyomiGoBack)
 
 " vim-go
 " See https://github.com/fatih/vim-go#example-mappings for mapping details

--- a/.vimrc
+++ b/.vimrc
@@ -140,6 +140,7 @@ Plug 'elixir-lang/vim-elixir', { 'for': 'elixir' }
 Plug 'rhysd/vim-crystal', { 'for': 'crystal' }
 Plug 'pangloss/vim-javascript', { 'for': ['javascript', 'javascript.jsx'] } | Plug 'mxw/vim-jsx', { 'for': 'javascript.jsx' }
 Plug 'leafgarland/typescript-vim', { 'for': 'typescript' }
+Plug 'Quramy/tsuquyomi', { 'for': 'typescript' }
 Plug 'fatih/vim-go', { 'for': 'go' }
 Plug 'rust-lang/rust.vim', { 'for': 'rust' }
 Plug 'dag/vim-fish', { 'for': 'fish' }
@@ -365,6 +366,13 @@ else
   autocmd vimrc BufEnter,BufWritePost * Neomake
   let g:neomake_verbose = 0
 endif
+
+" tsuquyomi
+let g:tsuquyomi_completion_detail = 1
+augroup tsuquyomi_specific
+  autocmd!
+  autocmd FileType typescript map <buffer> <C-\> <Plug>(TsuquyomiGoBack)
+augroup END
 
 " vim-go
 " See https://github.com/fatih/vim-go#example-mappings for mapping details

--- a/.vimrc
+++ b/.vimrc
@@ -139,6 +139,7 @@ Plug 'neovimhaskell/haskell-vim', { 'for': ['haskell', 'cabal'] }
 Plug 'elixir-lang/vim-elixir', { 'for': 'elixir' }
 Plug 'rhysd/vim-crystal', { 'for': 'crystal' }
 Plug 'pangloss/vim-javascript', { 'for': ['javascript', 'javascript.jsx'] } | Plug 'mxw/vim-jsx', { 'for': 'javascript.jsx' }
+Plug 'leafgarland/typescript-vim', { 'for': 'typescript' }
 Plug 'fatih/vim-go', { 'for': 'go' }
 Plug 'rust-lang/rust.vim', { 'for': 'rust' }
 Plug 'dag/vim-fish', { 'for': 'fish' }


### PR DESCRIPTION
- typescript-vim を追加
- typescript の filetype の設定を追加 (2タブにしてあります)
- tsuquyomi を追加
- tsuquyomi の設定を追加
  - `tsuquyomi_completion_detail` は ON にすると遅くなるらしいですが、あった方が便利そうなのでとりあえず ON
  - `tsuquyomi_disable_quickfix`はコンパイルエラーなどは neomake のtsc に任せる方向で disable
  - 自分の tmux の prefix `c-t` とぶつかったので `TsuquyomiGoBack` のキーマップを別途追加してます。

個別の言語の細かいプラグインの設定までは readme に書くことはしていません。tsuquyomi の詳細は https://github.com/Quramy/tsuquyomi をみてください。