### PR TITLE
unite-outline を denite が有効であれば denite 経由で呼ぶように

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -278,6 +278,9 @@ if get(g:, 'load_denite')
   nnoremap <silent> [rails]v :<C-u>Denite<Space>rails:view<Return>
   nnoremap <silent> [rails]h :<C-u>Denite<Space>rails:helper<Return>
   nnoremap <silent> [rails]t :<C-u>Denite<Space>rails:test<Return>
+
+  " unite-outline (to call it via denite)
+  nnoremap <silent> [unite]o :<C-u>Denite unite:outline<Return>
 endif
 
 " Neosnippet


### PR DESCRIPTION
unite のソースは denite 経由でも呼び出せるので、unite-outline を denite 経由で呼べるようにキーマップを変更しました。

今までの unite-outline のようにサイドに出しっぱなしにできるような使い方ではなくなりますが、普段 denite を使ってるとインターフェースが変わるのがやりづらく感じたので提案です。

使ってそうなのは @ta1kt0me かな？どう思います？