### PR TITLE
Add vim-js-pretty-template

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -140,6 +140,7 @@ Plug 'rhysd/vim-crystal', { 'for': 'crystal' }
 Plug 'pangloss/vim-javascript', { 'for': ['javascript', 'javascript.jsx'] } | Plug 'mxw/vim-jsx', { 'for': 'javascript.jsx' }
 Plug 'leafgarland/typescript-vim', { 'for': 'typescript' }
 Plug 'Quramy/tsuquyomi', { 'for': 'typescript' }
+Plug 'Quramy/vim-js-pretty-template', { 'for': ['javascript', 'typescript'] }
 Plug 'fatih/vim-go', { 'for': 'go' }
 Plug 'rust-lang/rust.vim', { 'for': 'rust' }
 Plug 'dag/vim-fish', { 'for': 'fish' }
@@ -364,6 +365,15 @@ else
   autocmd vimrc BufEnter,BufWritePost * Neomake
   let g:neomake_verbose = 0
 endif
+
+" vim-js-pretty-template
+autocmd FileType javascript JsPreTmpl html
+autocmd FileType javascript JsPreTmpl css
+autocmd FileType typescript JsPreTmpl html
+autocmd FileType typescript JsPreTmpl css
+" For leafgarland/typescript-vim users only.
+" Please see https://github.com/Quramy/vim-js-pretty-template/issues/1 for details.
+autocmd FileType typescript syn clear foldBraces
 
 " tsuquyomi
 let g:tsuquyomi_completion_detail = 1

--- a/.vimrc
+++ b/.vimrc
@@ -368,9 +368,7 @@ endif
 
 " vim-js-pretty-template
 autocmd FileType javascript JsPreTmpl html
-autocmd FileType javascript JsPreTmpl css
 autocmd FileType typescript JsPreTmpl html
-autocmd FileType typescript JsPreTmpl css
 " For leafgarland/typescript-vim users only.
 " Please see https://github.com/Quramy/vim-js-pretty-template/issues/1 for details.
 autocmd FileType typescript syn clear foldBraces


### PR DESCRIPTION
JS の Template Strings をシンタックスハイライトして欲しかったので、
https://github.com/Quramy/vim-js-pretty-template を追加しました。

<img width="1601" alt="screen shot 2017-05-09 at 14 33 54" src="https://cloud.githubusercontent.com/assets/333180/25836813/db90a534-34c4-11e7-9991-3b0465038717.png">
