### PR TITLE
JSONの整形コマンドを追加

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -404,6 +404,25 @@ let g:vimwiki_use_calendar = 1
 
 " }}}
 
+" Extra Commands
+" ------------------------------------------------
+" {{{1
+
+" Prettify JSON
+if executable('jq')
+  command! PrettyJson :execute "%!jq '.'"
+elseif executable('python2')
+  command! PrettyJson :execute '%!python2 -c "import sys, json;
+    \ print json.dumps(json.loads(sys.stdin.read()), indent=2,
+    \ separators=(\",\", \": \"), ensure_ascii=False)"'
+else
+  command! PrettyJson :execute '%!python -c "import sys, json;
+    \ print json.dumps(json.loads(sys.stdin.read()), indent=2,
+    \ separators=(\",\", \": \"), ensure_ascii=False)"'
+endif
+
+" }}}
+
 " Load Your Local .vimrc
 " ------------------------------------------------
 " {{{1

--- a/.vimrc
+++ b/.vimrc
@@ -414,11 +414,11 @@ if executable('jq')
 elseif executable('python2')
   command! PrettyJson :execute '%!python2 -c "import sys, json;
     \ print json.dumps(json.loads(sys.stdin.read()), indent=2,
-    \ separators=(\",\", \": \"), ensure_ascii=False)"'
+    \ separators=(\",\", \": \"), ensure_ascii=False).encode(\"utf8\")"'
 else
   command! PrettyJson :execute '%!python -c "import sys, json;
     \ print json.dumps(json.loads(sys.stdin.read()), indent=2,
-    \ separators=(\",\", \": \"), ensure_ascii=False)"'
+    \ separators=(\",\", \": \"), ensure_ascii=False).encode(\"utf8\")"'
 endif
 
 " }}}

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ augroup HTML
 augroup END
 ```
 
+### Prettify JSON
+
+You can prettify a JSON buffer by invoking `:PrettyJson`.
+It uses `jq` by default and fallbacks to use Python 2.x if `jq` is not available.
+
 ### vim-airline
 
 vim-airline provides nice looking status line. Visit https://github.com/vim-airline/vim-airline for details.


### PR DESCRIPTION
`:PrettyJson` コマンドで JSON の整形ができるようにしました。

- `jq` がインストールされている場合はそれを使って整形します
- ない場合は、Python 2.x で整形します
  - `python2` コマンドがあればそれで実行します
  - なければ `python` コマンドを使います
- 全て見つからなければ `PrettyJson` コマンドは定義されません

`python` コマンドは環境によっては Python 3.x の可能性もあるためこうしています。

Python 3.x しか入っておらず、かつそれが `python` コマンドで実行できる場合のみエラーになる可能性がありますが、レアケースと思うの特にそれを考慮はしていません。