### PR TITLE
Denite の file_rec ソースの custom matchers の設定を修正

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -307,7 +307,7 @@ if get(g:, 'load_cpsm')
 
   " Denite.vim integration
   if get(g:, 'load_denite')
-    call denite#custom#source('file_rec', 'matcher', ['matcher_cpsm'])
+    call denite#custom#source('file_rec', 'matchers', ['matcher_cpsm'])
   endif
 endif
 


### PR DESCRIPTION
cpsm が有効な場合、Denite の file_rec ソースで custom matcher として使う設定にしていましたが、今までずっと間違って設定になって動いていませんでした…

先日 Denite に間違ったオプションをチェックする機能が追加され、それで顕在化しました。
https://github.com/Shougo/denite.nvim/commit/e8a0b3f88831c6f26566e2de2412a3ec3d4f128b

そもそも `file_rec` はあんまり使っている人いなそうですが、このままだと Denite をアップデートすると cpsm 使ってると file_rec 使わなくてもエラーが出続けるので修正します。

レビューもちとめんどいしエラー対応なのでこのままマージさせてください。