### PR TITLE
バックアップを有効化

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -60,6 +60,7 @@ if !isdirectory(expand('~/.vim/tmp'))
 endif
 
 set directory=~/.vim/tmp
+set backup
 set backupdir=~/.vim/tmp
 set undodir=~/.vim/tmp
 


### PR DESCRIPTION
`set backupdir=~/.vim/tmp` を設定していますが、そもそもこれ `set backup` してないから意味なかったんじゃないか説がでてきました。

#56 の persistent-undo と合わせて転ばぬ先の杖としてちゃんと設定しておきたいです。

これで、 ファイルを編集するごとに　`~/.vim/tmp` にバックアップファイル (`~` のついたファイル) が作成されるはずです。