### PR TITLE
Linter ツールを ALE に変更

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -157,6 +157,7 @@ Plug 'mattn/calendar-vim'
 Plug 'mtsmfm/unite-turnip'
 Plug 'ruby-formatter/rufo-vim', { 'for': 'ruby' }
 Plug 'posva/vim-vue', { 'for': 'vue' }
+Plug 'w0rp/ale'
 
 if get(g:, 'load_wakatime')
   Plug 'wakatime/vim-wakatime'
@@ -177,12 +178,6 @@ if get(g:, 'load_denite')
   endif
 else
   Plug 'basyura/unite-rails'
-endif
-
-if get(g:, 'load_syntastic')
-  Plug 'scrooloose/syntastic'
-else
-  Plug 'neomake/neomake'
 endif
 
 " Colorschemes
@@ -360,19 +355,6 @@ else
     " neocomplete.vim
     let g:neocomplete#enable_at_startup = 1
   endif
-endif
-
-if get(g:, 'load_syntastic')
-  " Syntastic
-  let g:syntastic_check_on_open = 1
-  let g:syntastic_check_on_wq = 0
-  let g:syntastic_mode_map = { 'mode': 'passive', 'active_filetypes': ['ruby', 'python'] }
-  let g:syntastic_ruby_checkers = ['rubocop', 'mri']
-  let g:syntastic_python_checkers = ['flake8']
-else
-  " neomake
-  autocmd vimrc BufEnter,BufWritePost * Neomake
-  let g:neomake_verbose = 0
 endif
 
 " vim-js-pretty-template

--- a/.vimrc.preset.sample
+++ b/.vimrc.preset.sample
@@ -1,9 +1,6 @@
 " if you use vim-watatime, uncomment this line
 " let g:load_wakatime = 1
 
-" if you want to use Syntastic rather than Neomake, uncomment this line
-" let g:load_syntastic = 1
-
 " if you want to use cpsm for CtrlP matcher, uncomment this line
 " (cpsm requires Vim compiled with the +python flag and C++ compiler supporting C++11)
 " let g:load_cpsm = 1

--- a/README.md
+++ b/README.md
@@ -375,23 +375,11 @@ vim-migemo is a plugin for [migemo (cmigemo)](http://www.kaoriya.net/software/cm
 
 For more information, visit https://github.com/haya14busa/vim-migemo
 
-### Neomake
+### ALE (Asynchronous Lint Engine)
 
-Neomake is a plugin for asynchronous `:make`.
+ALE is a plugin for providing asynchronous linting. It requires NeoVim 0.2.0+ and Vim 8.
 
-Although Neomake has quite a few builtin configuration by default (including `rubocop`), you are also able to add a specific maker in accordance with its file type. Say if you want to use `eslint` on the `javascritpt` files, you can add the following lines to `~/.vimrc.local`:
-
-```vim
-let g:neomake_javascript_enabled_makers = ['eslint']
-```
-
-For more information, visit https://github.com/neomake/neomake or `:help neomake`.
-
-### Syntastic
-
-Syntastic is a syntax checking plugin. You can use it as an alternative option to static code analysis plugin (Neomake by default). If you want to use it, uncomment `let g:load_synstastic = 1` in `~/.vimrc.preset` .
-
-For more information, visit https://github.com/vim-syntastic/syntastic or `:help syntastic`.
+For more information, visit https://github.com/w0rp/ale or `:help ale`.
 
 ### vim-surround
 


### PR DESCRIPTION
もうほとんどの環境で Vim 8.0 以上の非同期実装版が使えるかなと思うので、

- Syntastic/Neomake out
- ALE in

しました。

https://github.com/w0rp/ale

乗り換えたい理由はここで書くより、

- https://qiita.com/zaki-yama/items/6bcc24469d06acdf8643
- https://rcmdnk.com/blog/2017/09/25/computer-vim/

などを読んでもらった方が良いと思います。

どうでしょ？
