### PR TITLE
previmの開発ブランチが移行したので明示的に変更する

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -141,7 +141,7 @@ Plug 'junegunn/vim-easy-align'
 Plug 'scrooloose/nerdtree', { 'on': 'NERDTreeToggle' } | Plug 'Xuyuanp/nerdtree-git-plugin', { 'on': 'NERDTreeToggle' }
 Plug 'airblade/vim-gitgutter'
 Plug 'godlygeek/tabular', { 'for': 'markdown' } | Plug 'plasticboy/vim-markdown', { 'for': 'markdown' }
-Plug 'kannokanno/previm', { 'for': 'markdown' }
+Plug 'previm/previm', { 'for': 'markdown' }
 Plug 'tyru/open-browser.vim'
 Plug 'tyru/open-browser-github.vim'
 Plug 'tyru/caw.vim'

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ The one thing at least you have to know about previm is:
 
 - `<Leader>mp` : to preview markdown in a web browser
 
-For more information, visit https://github.com/kannokanno/previm or `:help previm`.
+For more information, visit https://github.com/previm/previm or `:help previm`.
 
 ### open-browser-github
 


### PR DESCRIPTION
previmの開発ブランチが
kannokanno/previm => previm/previm
に移行したため明示的に書き換えを行った

## 主な変更点

- vimrcのPluginで指定しているブランチを変更
- READMEの更新